### PR TITLE
Gui new configcreation

### DIFF
--- a/configuration.py
+++ b/configuration.py
@@ -954,10 +954,12 @@ class DatasetConfiguration(XmlBase):
             
             active = self.getNodeBool(node, 'Active')
             
-            if not self.nodeExists(node,'Relationship'):
-                filters.append(self.readSimpleFilter(node))                
-            else:
+            if node.localName == 'TimeOfDayFilter':
+                filters.append(self.readToDFilter(node))
+            elif self.nodeExists(node,'Relationship'):
                 filters.append(RelationshipFilter(node))
+            else:
+                filters.append(self.readSimpleFilter(node))
         
         return filters
     

--- a/pcwg_tool.py
+++ b/pcwg_tool.py
@@ -1182,9 +1182,24 @@ class DatasetConfigurationDialog(BaseConfigurationDialog):
                         self.referenceWindDirection.configure(state='disabled')
                         self.referenceWindDirectionOffset.configure(state='disabled')
 
+                elif self.hubWindSpeedMode.get() == "None":
+                        self.hubWindSpeed.configure(state='disabled')
+                        self.hubTurbulence.configure(state='disabled')
+                        self.turbineLocationWindSpeed.configure(state='disabled')
+                        self.calibrationDirectionsListBox.configure(state='disabled')
+                        self.deleteCalibrationDirectionButton.configure(state='disabled')
+                        self.editCalibrationDirectionButton.configure(state='disabled')
+                        self.newCalibrationDirectionButton.configure(state='disabled')
+                        self.calibrationStartDate.configure(state='disabled')
+                        self.calibrationEndDate.configure(state='disabled')
+                        self.siteCalibrationNumberOfSectors.configure(state='disabled')
+                        self.siteCalibrationCenterOfFirstSector.configure(state='disabled')
+                        self.referenceWindSpeed.configure(state='disabled')
+                        self.referenceWindSpeedStdDev.configure(state='disabled')
+                        self.referenceWindDirection.configure(state='disabled')
+                        self.referenceWindDirectionOffset.configure(state='disabled')
                 else:
                         raise Exception("Unknown hub wind speed mode: %s" % self.hubWindSpeedMode.get())
-                
                 
         def NewCalibrationDirection(self):
 


### PR DESCRIPTION
Peter,

Take a look at this proposed fix for the issue that was reported #30 

It severely prevents use of the GUI at the moment. You may want to solve this problem in a different way, but I basically created a validation rule for the default blank 'None' mode, which is not selectable in the GUI but is set as a default on creation of a new config.