### PR TITLE
try except on zero turbulence power curve

### DIFF
--- a/turbine.py
+++ b/turbine.py
@@ -44,7 +44,12 @@ class PowerCurve:
         self.turbulenceFunction = self.createFunction(powerCurveLevels[self.hubTurbulence], ws_data) if has_pc else None
 
         if (turbulenceRenormalisation and has_pc):
-            self.calcZeroTurbulencePowerCurve()
+            print "Calculating zero turbulence curve for {0} Power Curve".format(self.name)
+            try:
+                self.calcZeroTurbulencePowerCurve()
+                print "Calculation of zero turbulence curve for {0} Power Curve successful".format(self.name)
+            except:
+                print "Calculation of zero turbulence curve for {0} Power Curve unsuccessful".format(self.name)
 
     def calcZeroTurbulencePowerCurve(self):
         keys = sorted(self.powerCurveLevels[self.actualPower].keys())


### PR DESCRIPTION
try except on zero turbulence power curve - this should remove the
occurrences of non-convergence causing run failures.